### PR TITLE
[CHORE] buildkonfig 플러그인 추가, base url 설정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Create local.properties
       run: |
         if [ "${{ github.event_name }}" = "pull_request" ]; then
-          echo "base.url=https://example.com" > local.properties
+          echo "base.url=https://example.com/" > local.properties
         else
           if [ -z "${{ secrets.BASE_URL }}" ]; then
             echo "secrets.BASE_URL is missing. Failing the build." >&2
@@ -84,7 +84,7 @@ jobs:
     - name: Create local.properties
       run: |
         if [ "${{ github.event_name }}" = "pull_request" ]; then
-          echo "base.url=https://example.com" > local.properties
+          echo "base.url=https://example.com/" > local.properties
         else
           if [ -z "${{ secrets.BASE_URL }}" ]; then
             echo "secrets.BASE_URL is missing. Failing the build." >&2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,4 +102,10 @@ jobs:
     - name: Build iOS App
       run: |
         cd iosApp
-        xcodebuild -project iosApp.xcodeproj -scheme iosApp -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' build CODE_SIGNING_ALLOWED=NO
+        xcodebuild \
+        -project iosApp.xcodeproj \
+        -scheme iosApp \
+        -sdk iphonesimulator \
+        -configuration Debug \
+        -destination 'generic/platform=iOS Simulator' \
+        build CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,11 @@ jobs:
         if [ "${{ github.event_name }}" = "pull_request" ]; then
           echo "base.url=https://example.com" > local.properties
         else
-          echo "base.url=${{ secrets.BASE_URL }}" > local.properties
-          if [ ! -s local.properties ]; then
-            echo "base.url=https://example.com" > local.properties
+          if [ -z "${{ secrets.BASE_URL }}" ]; then
+            echo "secrets.BASE_URL is missing. Failing the build." >&2
+            exit 1
           fi
+          echo "base.url=${{ secrets.BASE_URL }}" > local.properties
         fi
 
     - name: Build Android Debug APK
@@ -85,10 +86,11 @@ jobs:
         if [ "${{ github.event_name }}" = "pull_request" ]; then
           echo "base.url=https://example.com" > local.properties
         else
-          echo "base.url=${{ secrets.BASE_URL }}" > local.properties
-          if [ ! -s local.properties ]; then
-            echo "base.url=https://example.com" > local.properties
+          if [ -z "${{ secrets.BASE_URL }}" ]; then
+            echo "secrets.BASE_URL is missing. Failing the build." >&2
+            exit 1
           fi
+          echo "base.url=${{ secrets.BASE_URL }}" > local.properties
         fi
 
     - name: Build iOS Framework for Simulator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gradle-
 
+    - name: Create local.properties
+      run: |
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          echo "base.url=https://example.com" > local.properties
+        else
+          echo "base.url=${{ secrets.BASE_URL }}" > local.properties
+          if [ ! -s local.properties ]; then
+            echo "base.url=https://example.com" > local.properties
+          fi
+        fi
+
     - name: Build Android Debug APK
       run: ./gradlew assembleDebug --stacktrace
 
@@ -68,6 +79,17 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
         restore-keys: |
           ${{ runner.os }}-gradle-
+
+    - name: Create local.properties
+      run: |
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          echo "base.url=https://example.com" > local.properties
+        else
+          echo "base.url=${{ secrets.BASE_URL }}" > local.properties
+          if [ ! -s local.properties ]; then
+            echo "base.url=https://example.com" > local.properties
+          fi
+        fi
 
     - name: Build iOS Framework for Simulator
       run: ./gradlew linkDebugFrameworkIosSimulatorArm64 --stacktrace

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,4 +7,5 @@ plugins {
     alias(libs.plugins.composeMultiplatform) apply false
     alias(libs.plugins.composeCompiler) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
+    alias(libs.plugins.buildkonfig) apply false
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -17,7 +17,7 @@ buildkonfig {
     packageName = "org.whosin.client"
 
     defaultConfigs {
-        val baseUrl = gradleLocalProperties(rootDir, providers).getProperty("base.url")
+        val baseUrl = gradleLocalProperties(rootDir, providers).getProperty("base.url") ?: "httpsL//example.com"
         buildConfigField(
             com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING,
             "BASE_URL",

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,7 +1,7 @@
+import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -10,6 +10,20 @@ plugins {
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeHotReload)
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.buildkonfig)
+}
+
+buildkonfig {
+    packageName = "org.whosin.client"
+
+    defaultConfigs {
+        val baseUrl = gradleLocalProperties(rootDir, providers).getProperty("base.url")
+        buildConfigField(
+            com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING,
+            "BASE_URL",
+            baseUrl
+        )
+    }
 }
 
 kotlin {

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -17,7 +17,7 @@ buildkonfig {
     packageName = "org.whosin.client"
 
     defaultConfigs {
-        val baseUrl = gradleLocalProperties(rootDir, providers).getProperty("base.url") ?: "httpsL//example.com"
+        val baseUrl = gradleLocalProperties(rootDir, providers).getProperty("base.url") ?: "https://example.com"
         buildConfigField(
             com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING,
             "BASE_URL",

--- a/composeApp/src/commonMain/kotlin/org/whosin/client/core/network/HttpClientFactory.kt
+++ b/composeApp/src/commonMain/kotlin/org/whosin/client/core/network/HttpClientFactory.kt
@@ -14,8 +14,10 @@ import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
+import org.whosin.client.BuildKonfig
 
 object HttpClientFactory {
+    val BASE_URL = BuildKonfig.BASE_URL
     fun create(engine: HttpClientEngine): HttpClient {
         return HttpClient(engine) {
             install(ContentNegotiation) {
@@ -37,10 +39,11 @@ object HttpClientFactory {
                         println(message)
                     }
                 }
-                level = LogLevel.ALL
+                level = LogLevel.BODY
             }
             defaultRequest {
                 contentType(ContentType.Application.Json)
+                url(BASE_URL)
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/whosin/client/data/remote/DummyDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/org/whosin/client/data/remote/DummyDataSource.kt
@@ -5,6 +5,7 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.isSuccess
+import org.whosin.client.BuildKonfig
 import org.whosin.client.core.network.ApiResult
 import org.whosin.client.data.dto.response.DummyJokeResponseDto
 
@@ -14,7 +15,8 @@ class DummyDataSource(
     suspend fun getRandomJoke(): ApiResult<DummyJokeResponseDto> {
         return try {
             val response: HttpResponse = client
-                .get(urlString = "https://official-joke-api.appspot.com/jokes/random")
+                .get(urlString = "https://official-joke-api.appspot.com/jokes/random") // base url을 사용하지 않는 경우에는 full url 작성
+//                .get(urlString = "jokes/random") // base url을 사용하는 경우에는 base url 이후 경로 작성
             if (response.status.isSuccess()) {
                 ApiResult.Success(
                     data = response.body(),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ navigation-compose = "2.9.0-beta03"
 ktor = "3.2.3"
 kotlinx-serialization = "1.9.0"
 koin = "4.1.0"
+buildkonfig = "0.17.1"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -58,3 +59,4 @@ composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMul
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+buildkonfig = { id = "com.codingfeline.buildkonfig", version.ref = "buildkonfig" }


### PR DESCRIPTION
## 🚀 이슈번호
- closes #9 

## ✏️ 변경사항
- kmp에서 build config와 같은 기능을 사용할 수 있게 해주는 buildkonfig 플러그인 적용
- ktor client에서 기본 요청에 BuildKonfig를 통해 base url을 사용하도록 지정
- github ci 에서 ios를 sdk 시뮬레이터로 빌드하도록 수정

## 📷 스크린샷


## ✍️ 사용법
- local.properties에 base.url=https://example.com/ 와 같이 값을 지정해두고 BuildKonfig를 통해 접근 가능(현재 코드로는 BuildKonfig.BASE_URL 로 접근)
- 만약 일부 요청에 다른 base url을 사용해야 하는 경우에는 ktor client를 통해 api 요청시 전체 url을 지정해서 요청하면 됨
    - https://api.ktor.io/ktor-client/ktor-client-core/io.ktor.client.plugins/-default-request/index.html?utm_source

## 🎸 기타


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - 네트워크 기본 URL을 빌드 구성에서 제공해 모든 요청의 기본 엔드포인트가 통일되었습니다.
  - HTTP 로그 레벨을 ALL에서 BODY로 낮춰 출력되는 로그 양이 줄었습니다.
- Chores
  - BuildKonfig 기반 빌드 설정이 추가되어 런타임 구성값(예: BASE_URL)을 빌드에 포함합니다.
  - 버전 카탈로그에 BuildKonfig 항목이 추가되어 의존성 관리가 확장되었습니다.
- CI
  - CI 워크플로에서 local.properties를 생성해 base.url 값을 환경별로 일관되게 설정합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->