### PR TITLE
[FEAT] 동아리 추가 기능 구현

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/whosin/client/data/dto/response/AddClubResponseDto.kt
+++ b/composeApp/src/commonMain/kotlin/org/whosin/client/data/dto/response/AddClubResponseDto.kt
@@ -1,0 +1,16 @@
+package org.whosin.client.data.dto.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AddClubResponseDto(
+    @SerialName("success")
+    val success: Boolean,
+    @SerialName("status")
+    val status: Int,
+    @SerialName("message")
+    val message: String,
+    @SerialName("data")
+    val data: String? = null
+)

--- a/composeApp/src/commonMain/kotlin/org/whosin/client/data/dto/response/ClubCodeConfirmResponseDto.kt
+++ b/composeApp/src/commonMain/kotlin/org/whosin/client/data/dto/response/ClubCodeConfirmResponseDto.kt
@@ -1,0 +1,24 @@
+package org.whosin.client.data.dto.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ClubCodeConfirmResponseDto(
+    @SerialName("success")
+    val success: Boolean,
+    @SerialName("status")
+    val status: Int,
+    @SerialName("message")
+    val message: String,
+    @SerialName("data")
+    val data: ClubCodeConfirmData
+)
+
+@Serializable
+data class ClubCodeConfirmData(
+    @SerialName("clubId")
+    val clubId: Int,
+    @SerialName("clubName")
+    val clubName: String
+)

--- a/composeApp/src/commonMain/kotlin/org/whosin/client/data/dto/response/ErrorResponseDto.kt
+++ b/composeApp/src/commonMain/kotlin/org/whosin/client/data/dto/response/ErrorResponseDto.kt
@@ -1,0 +1,16 @@
+package org.whosin.client.data.dto.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ErrorResponseDto(
+    @SerialName("success")
+    val success: Boolean,
+    @SerialName("status")
+    val status: Int,
+    @SerialName("message")
+    val message: String,
+    @SerialName("timestamp")
+    val timestamp: String? = null
+)

--- a/composeApp/src/commonMain/kotlin/org/whosin/client/data/remote/RemoteClubDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/org/whosin/client/data/remote/RemoteClubDataSource.kt
@@ -13,6 +13,7 @@ import org.whosin.client.core.network.ApiResult
 import org.whosin.client.data.dto.response.AddClubResponseDto
 import org.whosin.client.data.dto.response.ClubCodeConfirmResponseDto
 import org.whosin.client.data.dto.response.ClubPresencesResponseDto
+import org.whosin.client.data.dto.response.ErrorResponseDto
 import org.whosin.client.data.dto.response.MyClubResponseDto
 
 class RemoteClubDataSource(
@@ -111,10 +112,20 @@ class RemoteClubDataSource(
                     statusCode = response.status.value
                 )
             } else {
-                ApiResult.Error(
-                    code = response.status.value,
-                    message = "HTTP Error: ${response.status.value}"
-                )
+                // 에러 응답 파싱 시도
+                try {
+                    val errorResponse: ErrorResponseDto = response.body()
+                    ApiResult.Error(
+                        code = response.status.value,
+                        message = errorResponse.message
+                    )
+                } catch (e: Exception) {
+                    // 파싱 실패 시 기본 에러 메시지
+                    ApiResult.Error(
+                        code = response.status.value,
+                        message = "HTTP Error: ${response.status.value}"
+                    )
+                }
             }
         } catch (t: Throwable){
             ApiResult.Error(message = t.message, cause = t)

--- a/composeApp/src/commonMain/kotlin/org/whosin/client/data/remote/RemoteClubDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/org/whosin/client/data/remote/RemoteClubDataSource.kt
@@ -4,10 +4,14 @@ import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
+import io.ktor.client.request.parameter
 import io.ktor.client.request.post
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.isSuccess
+import io.ktor.http.parameters
 import org.whosin.client.core.network.ApiResult
+import org.whosin.client.data.dto.response.AddClubResponseDto
+import org.whosin.client.data.dto.response.ClubCodeConfirmResponseDto
 import org.whosin.client.data.dto.response.ClubPresencesResponseDto
 import org.whosin.client.data.dto.response.MyClubResponseDto
 
@@ -90,6 +94,50 @@ class RemoteClubDataSource(
                 )
             }
         } catch (t: Throwable) {
+            ApiResult.Error(message = t.message, cause = t)
+        }
+    }
+
+    // 동아리 번호 확인
+    suspend fun confirmClubCode(clubCode: String): ApiResult<ClubCodeConfirmResponseDto>{
+        return try {
+            val response: HttpResponse = client.get(urlString = "clubs"){
+                parameter("clubNumber", clubCode)
+            }
+
+            if (response.status.isSuccess()) {
+                ApiResult.Success(
+                    data = response.body(),
+                    statusCode = response.status.value
+                )
+            } else {
+                ApiResult.Error(
+                    code = response.status.value,
+                    message = "HTTP Error: ${response.status.value}"
+                )
+            }
+        } catch (t: Throwable){
+            ApiResult.Error(message = t.message, cause = t)
+        }
+    }
+
+    // 동아리 추가 함수
+    suspend fun addClub(clubId: Int): ApiResult<AddClubResponseDto> {
+        return try {
+            val response: HttpResponse = client.get(urlString = "clubs/$clubId")
+
+            if (response.status.isSuccess()) {
+                ApiResult.Success(
+                    data = response.body(),
+                    statusCode = response.status.value
+                )
+            } else {
+                ApiResult.Error(
+                    code = response.status.value,
+                    message = "HTTP Error: ${response.status.value}"
+                )
+            }
+        } catch (t: Throwable){
             ApiResult.Error(message = t.message, cause = t)
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/whosin/client/data/remote/RemoteClubDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/org/whosin/client/data/remote/RemoteClubDataSource.kt
@@ -135,7 +135,7 @@ class RemoteClubDataSource(
     // 동아리 추가 함수
     suspend fun addClub(clubId: Int): ApiResult<AddClubResponseDto> {
         return try {
-            val response: HttpResponse = client.get(urlString = "clubs/$clubId")
+            val response: HttpResponse = client.post(urlString = "clubs/$clubId")
 
             if (response.status.isSuccess()) {
                 ApiResult.Success(
@@ -143,10 +143,20 @@ class RemoteClubDataSource(
                     statusCode = response.status.value
                 )
             } else {
-                ApiResult.Error(
-                    code = response.status.value,
-                    message = "HTTP Error: ${response.status.value}"
-                )
+                // 에러 응답 파싱 시도
+                try {
+                    val errorResponse: ErrorResponseDto = response.body()
+                    ApiResult.Error(
+                        code = response.status.value,
+                        message = errorResponse.message
+                    )
+                } catch (e: Exception) {
+                    // 파싱 실패 시 기본 에러 메시지
+                    ApiResult.Error(
+                        code = response.status.value,
+                        message = "HTTP Error: ${response.status.value}"
+                    )
+                }
             }
         } catch (t: Throwable){
             ApiResult.Error(message = t.message, cause = t)

--- a/composeApp/src/commonMain/kotlin/org/whosin/client/data/repository/ClubRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/whosin/client/data/repository/ClubRepository.kt
@@ -1,6 +1,8 @@
 package org.whosin.client.data.repository
 
 import org.whosin.client.core.network.ApiResult
+import org.whosin.client.data.dto.response.AddClubResponseDto
+import org.whosin.client.data.dto.response.ClubCodeConfirmResponseDto
 import org.whosin.client.data.dto.response.ClubPresencesResponseDto
 import org.whosin.client.data.dto.response.MyClubResponseDto
 import org.whosin.client.data.remote.RemoteClubDataSource
@@ -19,4 +21,10 @@ class ClubRepository(
 
     suspend fun checkOut(clubId: Int): ApiResult<Unit> =
         dataSource.checkOut(clubId)
+
+    suspend fun confirmClubCode(clubCode: String): ApiResult<ClubCodeConfirmResponseDto> =
+        dataSource.confirmClubCode(clubCode)
+
+    suspend fun addClub(clubId: Int): ApiResult<AddClubResponseDto> =
+        dataSource.addClub(clubId)
 }

--- a/composeApp/src/commonMain/kotlin/org/whosin/client/di/DIModules.kt
+++ b/composeApp/src/commonMain/kotlin/org/whosin/client/di/DIModules.kt
@@ -10,6 +10,7 @@ import org.whosin.client.data.remote.RemoteMemberDataSource
 import org.whosin.client.data.repository.DummyRepository
 import org.whosin.client.data.repository.ClubRepository
 import org.whosin.client.data.repository.MemberRepository
+import org.whosin.client.presentation.auth.clubcode.AddClubViewModel
 import org.whosin.client.presentation.dummy.DummyViewModel
 import org.whosin.client.presentation.dummy.TokenTestViewModel
 import org.whosin.client.presentation.auth.login.viewmodel.LoginViewModel
@@ -49,4 +50,5 @@ val viewModelModule = module {
     viewModelOf(::MyPageViewModel)
     viewModelOf(::DummyViewModel) // TODO: 이후에 삭제 예정
     viewModelOf(::TokenTestViewModel) // TODO: 이후에 삭제 예정
+    viewModelOf(::AddClubViewModel)
 }

--- a/composeApp/src/commonMain/kotlin/org/whosin/client/presentation/auth/clubcode/AddClubViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/whosin/client/presentation/auth/clubcode/AddClubViewModel.kt
@@ -1,0 +1,12 @@
+package org.whosin.client.presentation.auth.clubcode
+
+import org.whosin.client.data.repository.ClubRepository
+
+class AddClubViewModel(
+    private val repository: ClubRepository
+) {
+
+    // TODO: 동아리 번호 확인 함수
+
+    // TODO: 동아리 추가 함수
+}

--- a/composeApp/src/commonMain/kotlin/org/whosin/client/presentation/auth/clubcode/AddClubViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/whosin/client/presentation/auth/clubcode/AddClubViewModel.kt
@@ -44,7 +44,7 @@ class AddClubViewModel(
                     _uiState.update {
                         it.copy(
                             isLoading = false,
-                            errorMessage = result.message ?: "조회시에 오류가 발생했습니다."
+                            errorMessage = result.message ?: "동아리 이름 조회에 오류가 발생했습니다."
                         )
                     }
                 }
@@ -52,17 +52,26 @@ class AddClubViewModel(
         }
     }
 
-    // TODO: 동아리 추가 함수
+    // 동아리 추가 함수
     fun addClub(clubId: Int) {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true) }
             when (val result = repository.addClub(clubId = clubId)) {
                 is ApiResult.Success -> {
-
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            errorMessage = null
+                        )
+                    }
                 }
-
                 is ApiResult.Error -> {
-
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            errorMessage = result.message ?: "동아리 추가에 오류가 발생했습니다."
+                        )
+                    }
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/org/whosin/client/presentation/auth/clubcode/AddClubViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/whosin/client/presentation/auth/clubcode/AddClubViewModel.kt
@@ -15,7 +15,8 @@ data class AddClubUiState(
     val verificationState: ClubCodeState = ClubCodeState.INPUT,
     val clubName: String? = null,
     val clubId: Int? = null,
-    val errorMessage: String? = null
+    val errorMessage: String? = null,
+    val isAddClubSuccess: Boolean = false
 )
 
 class AddClubViewModel(
@@ -76,7 +77,8 @@ class AddClubViewModel(
                     _uiState.update {
                         it.copy(
                             isLoading = false,
-                            errorMessage = null
+                            errorMessage = null,
+                            isAddClubSuccess = true
                         )
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/org/whosin/client/presentation/auth/clubcode/AddClubViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/whosin/client/presentation/auth/clubcode/AddClubViewModel.kt
@@ -1,12 +1,70 @@
 package org.whosin.client.presentation.auth.clubcode
 
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.whosin.client.core.network.ApiResult
 import org.whosin.client.data.repository.ClubRepository
+
+data class AddClubUiState(
+    val isLoading: Boolean = false,
+    val verificationState: ClubCodeState = ClubCodeState.INPUT,
+    val clubName: String? = null,
+    val clubId: Int? = null,
+    val errorMessage: String? = null
+)
 
 class AddClubViewModel(
     private val repository: ClubRepository
-) {
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(AddClubUiState())
+    val uiState: StateFlow<AddClubUiState> = _uiState.asStateFlow()
 
-    // TODO: 동아리 번호 확인 함수
+    fun confirmClubCode(clubCode: String) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            when (val result = repository.confirmClubCode(clubCode = clubCode)) {
+                is ApiResult.Success -> {
+                    val response = result.data.data
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            verificationState = ClubCodeState.SUCCESS,
+                            clubName = response.clubName,
+                            clubId = response.clubId,
+                            errorMessage = null
+                        )
+                    }
+                }
+                is ApiResult.Error -> {
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            errorMessage = result.message ?: "조회시에 오류가 발생했습니다."
+                        )
+                    }
+                }
+            }
+        }
+    }
 
     // TODO: 동아리 추가 함수
+    fun addClub(clubId: Int) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            when (val result = repository.addClub(clubId = clubId)) {
+                is ApiResult.Success -> {
+
+                }
+
+                is ApiResult.Error -> {
+
+                }
+            }
+        }
+    }
 }

--- a/composeApp/src/commonMain/kotlin/org/whosin/client/presentation/auth/clubcode/AddClubViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/whosin/client/presentation/auth/clubcode/AddClubViewModel.kt
@@ -39,15 +39,17 @@ class AddClubViewModel(
                             errorMessage = null
                         )
                     }
+                    println("AddClubViewModel : 조회 성공")
                 }
                 is ApiResult.Error -> {
                     _uiState.update {
                         it.copy(
                             isLoading = false,
                             verificationState = ClubCodeState.ERROR,
-                            errorMessage = result.message ?: "동아리 이름 조회에 오류가 발생했습니다."
+                            errorMessage = result.message?: "동아리 이름 조회에 오류가 발생했습니다."
                         )
                     }
+                    println("AddClubViewModel : 조회 실패")
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/org/whosin/client/presentation/auth/clubcode/AddClubViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/whosin/client/presentation/auth/clubcode/AddClubViewModel.kt
@@ -44,11 +44,24 @@ class AddClubViewModel(
                     _uiState.update {
                         it.copy(
                             isLoading = false,
+                            verificationState = ClubCodeState.ERROR,
                             errorMessage = result.message ?: "동아리 이름 조회에 오류가 발생했습니다."
                         )
                     }
                 }
             }
+        }
+    }
+
+    // 에러 상태 리셋 함수
+    fun resetErrorState() {
+        _uiState.update {
+            it.copy(
+                verificationState = ClubCodeState.INPUT,
+                errorMessage = null,
+                clubName = null,
+                clubId = null
+            )
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/org/whosin/client/presentation/auth/clubcode/ClubCodeInputScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/whosin/client/presentation/auth/clubcode/ClubCodeInputScreen.kt
@@ -53,15 +53,13 @@ fun ClubCodeInputScreen(
     modifier: Modifier = Modifier,
     onNavigateBack: () -> Unit = {},
     onNavigateToHome: () -> Unit = {},
-    onErrorReset: () -> Unit = {},
-    verificationState: ClubCodeState = ClubCodeState.INPUT, // TODO: viewmodel로 리팩토링
     viewModel: AddClubViewModel = koinViewModel()
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
 
     var clubCode by remember { mutableStateOf(arrayOf("", "", "", "", "", "")) }
     var currentFocusIndex by remember { mutableStateOf(0) }
-    val currentState = verificationState // TODO: uiState의 verificationState를 사용하도록 리팩토링
+    val currentState = uiState.verificationState
     val focusRequesters = remember { List(6) { FocusRequester() } }
     val keyboardController = LocalSoftwareKeyboardController.current
 
@@ -84,7 +82,7 @@ fun ClubCodeInputScreen(
             clubCode = arrayOf("", "", "", "", "", "")
             currentFocusIndex = 0
             focusRequesters[0].requestFocus()
-//            onErrorReset()
+            viewModel.resetErrorState()
         }
     }
 
@@ -256,7 +254,8 @@ fun ClubCodeInputScreen(
             onClick = {
                 if (currentState == ClubCodeState.SUCCESS) {
                     if (uiState.clubId != null){
-                        viewModel.addClub(uiState.clubId)
+//                        viewModel.addClub(uiState.clubId)
+                        println("확인 버튼 클릭")
                         // TODO: 추가 완료시 넘어가도록
                     }
                 } else {
@@ -275,16 +274,9 @@ fun ClubCodeInputScreen(
 @Preview
 @Composable
 fun ClubCodeInputScreenPreview() {
-    var verificationState by remember { mutableStateOf(ClubCodeState.INPUT) }
-    var clubName by remember { mutableStateOf("") }
-
     ClubCodeInputScreen(
         modifier = Modifier,
-        verificationState = verificationState,
         onNavigateBack = {},
-        onNavigateToHome = { },
-        onErrorReset = {
-            verificationState = ClubCodeState.INPUT
-        }
+        onNavigateToHome = { }
     )
 }

--- a/composeApp/src/commonMain/kotlin/org/whosin/client/presentation/auth/clubcode/ClubCodeInputScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/whosin/client/presentation/auth/clubcode/ClubCodeInputScreen.kt
@@ -186,7 +186,7 @@ fun ClubCodeInputScreen(
             // 에러 메시지
             if (currentState == ClubCodeState.ERROR) {
                 Text(
-                    text = stringResource(Res.string.club_code_error_message),
+                    text = uiState.errorMessage?:"예상치 못한 오류가 발생했습니다",
                     fontSize = 16.sp,
                     fontWeight = FontWeight.W500,
                     color = Color(0xFFFF3636),

--- a/composeApp/src/commonMain/kotlin/org/whosin/client/presentation/auth/clubcode/ClubCodeInputScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/whosin/client/presentation/auth/clubcode/ClubCodeInputScreen.kt
@@ -84,6 +84,9 @@ fun ClubCodeInputScreen(
             focusRequesters[0].requestFocus()
             viewModel.resetErrorState()
         }
+        if (currentState == ClubCodeState.SUCCESS){
+            keyboardController?.hide()
+        }
     }
 
     // 동아리 추가 성공 시 홈으로 이동

--- a/composeApp/src/commonMain/kotlin/org/whosin/client/presentation/auth/clubcode/ClubCodeInputScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/whosin/client/presentation/auth/clubcode/ClubCodeInputScreen.kt
@@ -31,10 +31,12 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.delay
 import coil3.compose.AsyncImage
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import org.koin.compose.viewmodel.koinViewModel
 import org.whosin.client.presentation.auth.login.component.CommonLoginButton
 import org.whosin.client.presentation.auth.login.component.NumberInputBox
 import whosinclient.composeapp.generated.resources.Res
@@ -50,15 +52,16 @@ import whosinclient.composeapp.generated.resources.confirm_button
 fun ClubCodeInputScreen(
     modifier: Modifier = Modifier,
     onNavigateBack: () -> Unit = {},
-    onNavigateToHome: (String) -> Unit = {},
-    onVerifyClubCode: (String) -> Unit = {},
+    onNavigateToHome: () -> Unit = {},
     onErrorReset: () -> Unit = {},
-    verificationState: ClubCodeState = ClubCodeState.INPUT,
-    clubName: String = ""
+    verificationState: ClubCodeState = ClubCodeState.INPUT, // TODO: viewmodel로 리팩토링
+    viewModel: AddClubViewModel = koinViewModel()
 ) {
+    val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
+
     var clubCode by remember { mutableStateOf(arrayOf("", "", "", "", "", "")) }
     var currentFocusIndex by remember { mutableStateOf(0) }
-    val currentState = verificationState
+    val currentState = verificationState // TODO: uiState의 verificationState를 사용하도록 리팩토링
     val focusRequesters = remember { List(6) { FocusRequester() } }
     val keyboardController = LocalSoftwareKeyboardController.current
 
@@ -81,7 +84,7 @@ fun ClubCodeInputScreen(
             clubCode = arrayOf("", "", "", "", "", "")
             currentFocusIndex = 0
             focusRequesters[0].requestFocus()
-            onErrorReset()
+//            onErrorReset()
         }
     }
 
@@ -206,7 +209,7 @@ fun ClubCodeInputScreen(
                     text = stringResource(Res.string.club_code_confirm_button),
                     onClick = {
                         if (isComplete) {
-                            onVerifyClubCode(fullCode)
+                            viewModel.confirmClubCode(clubCode = fullCode)
                         }
                     },
                     enabled = isComplete,
@@ -237,7 +240,7 @@ fun ClubCodeInputScreen(
                     contentAlignment = Alignment.Center
                 ) {
                     Text(
-                        text = clubName,
+                        text = uiState.clubName ?: "",
                         fontSize = 16.sp,
                         fontWeight = FontWeight.W500,
                         color = Color.Black,
@@ -252,7 +255,12 @@ fun ClubCodeInputScreen(
             text = stringResource(Res.string.confirm_button),
             onClick = {
                 if (currentState == ClubCodeState.SUCCESS) {
-                    onNavigateToHome(clubName)
+                    if (uiState.clubId != null){
+                        viewModel.addClub(uiState.clubId)
+                        // TODO: 추가 완료시 넘어가도록
+                    }
+                } else {
+                    println("ClubCodeInputScreen : 확인 버튼 오류")
                 }
             },
             enabled = currentState == ClubCodeState.SUCCESS,
@@ -273,17 +281,8 @@ fun ClubCodeInputScreenPreview() {
     ClubCodeInputScreen(
         modifier = Modifier,
         verificationState = verificationState,
-        clubName = clubName,
         onNavigateBack = {},
-        onNavigateToHome = { name -> println("Navigate to home with: $name") },
-        onVerifyClubCode = { code ->
-            if (code == "123456") {
-                verificationState = ClubCodeState.SUCCESS
-                clubName = "메이커스팜"
-            } else {
-                verificationState = ClubCodeState.ERROR
-            }
-        },
+        onNavigateToHome = { },
         onErrorReset = {
             verificationState = ClubCodeState.INPUT
         }

--- a/composeApp/src/commonMain/kotlin/org/whosin/client/presentation/auth/clubcode/ClubCodeInputScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/whosin/client/presentation/auth/clubcode/ClubCodeInputScreen.kt
@@ -86,6 +86,13 @@ fun ClubCodeInputScreen(
         }
     }
 
+    // 동아리 추가 성공 시 홈으로 이동
+    LaunchedEffect(uiState.isAddClubSuccess) {
+        if (uiState.isAddClubSuccess) {
+            onNavigateToHome()
+        }
+    }
+
     val fullCode = clubCode.joinToString("")
     val isComplete = fullCode.length == 6
 
@@ -197,6 +204,7 @@ fun ClubCodeInputScreen(
                 )
             }
 
+
             Box(
                 modifier = Modifier
                     .padding(top = if (currentState != ClubCodeState.ERROR) 48.dp else 0.dp)
@@ -245,6 +253,20 @@ fun ClubCodeInputScreen(
                         textAlign = TextAlign.Center
                     )
                 }
+
+                // 동아리 추가 실패 에러 메시지
+                if (uiState.errorMessage != null && !uiState.isAddClubSuccess) {
+                    Text(
+                        text = uiState.errorMessage,
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.W500,
+                        color = Color(0xFFFF3636),
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier
+                            .padding(top = 16.dp)
+                            .fillMaxWidth()
+                    )
+                }
             }
         }
 
@@ -254,9 +276,7 @@ fun ClubCodeInputScreen(
             onClick = {
                 if (currentState == ClubCodeState.SUCCESS) {
                     if (uiState.clubId != null){
-//                        viewModel.addClub(uiState.clubId)
-                        println("확인 버튼 클릭")
-                        // TODO: 추가 완료시 넘어가도록
+                        viewModel.addClub(uiState.clubId)
                     }
                 } else {
                     println("ClubCodeInputScreen : 확인 버튼 오류")

--- a/composeApp/src/commonMain/kotlin/org/whosin/client/presentation/auth/clubcode/ClubCodeInputScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/whosin/client/presentation/auth/clubcode/ClubCodeInputScreen.kt
@@ -219,6 +219,9 @@ fun ClubCodeInputScreen(
                     onClick = {
                         if (isComplete) {
                             viewModel.confirmClubCode(clubCode = fullCode)
+                            if (currentState == ClubCodeState.SUCCESS){
+                                keyboardController?.hide()
+                            }
                         }
                     },
                     enabled = isComplete,


### PR DESCRIPTION
## 🚀 이슈번호
- closes #28 

## ✏️ 변경사항
- 동아리 추가 화면에서 사용할 AddClubViewModel 작성, Di 모듈에 추가
- 동아리 코드를 통한 동아리 이름 확인 api 연결
- 동아리 추가 api 연결
- datasource에서 요청 오류에 대한 처리에 사용할 ErrorResponseDto 추가
- ui에 동아리 조회, 동아리 추가에 대한 오류 메세지 반영
- 동아리 조회 성공시 키보드 숨김 로직 추가
- 기존에 ClubCodeInputScreen에서 사용하던 상태 관련 변수들을 uiState로 리팩토링

## 📷 스크린샷
안드로이드

https://github.com/user-attachments/assets/9066d73b-7c7b-497c-973a-40ea1e4caf5d


iOS

https://github.com/user-attachments/assets/f2142b5f-2fc8-4751-8e3b-022248de6b8f


## ✍️ 사용법
- api 요청에 실패했을 때, 오류 메세지를 사용해야 되는 경우에는 dataSource에서 추가된 ErrorResponseDto를 사용해서 파싱하면 됩니다.

## 🎸 기타


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 클럽 코드 확인 및 클럽 추가 기능을 지원합니다.
  - 확인 성공 시 클럽 이름 표시 및 자동 추가/완료 처리, 홈으로 자동 이동을 제공합니다.
- Refactor
  - 클럽 코드 입력 화면이 ViewModel 기반 상태 관리로 전환되어 더 일관된 로딩/성공/오류 흐름을 제공합니다.
  - 오류 메시지가 구조화되어 표시되어 실패 원인을 명확히 안내합니다.
  - 입력 확인/성공 시 키보드 자동 숨김으로 사용성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->